### PR TITLE
Update 7zr.1

### DIFF
--- a/man1/7zr.1
+++ b/man1/7zr.1
@@ -35,7 +35,7 @@ Test
 Update
 .TP
 .B x
-eXtract with full paths
+Extract with full paths
 .PP
 .SH SWITCHES
 .TP
@@ -43,7 +43,7 @@ eXtract with full paths
 Include archives
 .TP
 .B \-ax[r[-|0]]{@listfile|!wildcard}
-eXclude archives
+Exclude archives
 .TP
 .B \-bd
 Disable percentage indicator


### PR DESCRIPTION
Fixed spelling mistake in two words: "eXtract and eXclude"